### PR TITLE
[IMP] hr_attendance_kanban: Minor improvements

### DIFF
--- a/hr_attendance_kanban/models/hr_employee.py
+++ b/hr_attendance_kanban/models/hr_employee.py
@@ -26,6 +26,7 @@ class HrEmployee(models.Model):
     @api.depends(
         "last_attendance_id.check_in",
         "last_attendance_id.check_out",
+        "last_attendance_id.attendance_type_id",
         "last_attendance_id",
     )
     def _compute_attendance_type_id(self):

--- a/hr_attendance_kanban/views/hr_attendance_view.xml
+++ b/hr_attendance_kanban/views/hr_attendance_view.xml
@@ -22,7 +22,7 @@
         <field name="priority">500</field>
         <field name="arch" type="xml">
             <field name="worked_hours" position="after">
-                <field name="attendance_type_id" />
+                <field name="attendance_type_id" domain="[('absent', '!=', True)]" />
                 <field name="comment" />
             </field>
         </field>

--- a/hr_attendance_kanban/wizard/hr_attendance_kanban_wizard_views.xml
+++ b/hr_attendance_kanban/wizard/hr_attendance_kanban_wizard_views.xml
@@ -24,7 +24,7 @@
                         />
                         <field
                             name="next_attendance_type_id"
-                            attrs="{'required': [('manual_mode', '=', True), ('attendance_state', '!=', 'checked_in')] , 'readonly': ['|', ('manual_mode', '!=', True), ('attendance_state', '!=', 'checked_out')], 'invisible': ['|', ('manual_mode', '!=', True), ('attendance_state', '!=', 'checked_out')]}"
+                            attrs="{'required': [('manual_mode', '=', True), ('attendance_state', '!=', 'checked_in')] , 'readonly': ['|', ('manual_mode', '!=', True), ('attendance_state', '!=', 'checked_out')], 'invisible': [('attendance_state', '!=', 'checked_out')]}"
                             domain="[('absent', '!=', True)]"
                             options="{'no_create': True}"
                         />


### PR DESCRIPTION
Fix manual attendance modification keeps employee attendance type in sync. Also include test to prove it. 

Ensure start time when checking out does not go empty after UserError is raised.

Always show Attendance Type on check in wizard